### PR TITLE
chore(dotenv): Add dotenv-rails gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ config/master.key
 # config/secrets.yml
 
 # dotenv
-# TODO Comment out this rule if environment variables can be committed
 .env
 
 ## Environment normalization:

--- a/Gemfile
+++ b/Gemfile
@@ -76,5 +76,8 @@ gem 'exception_handler', '~> 0.8.0.0'
 # Use haml for easy HTML generation
 gem 'haml'
 
+# dotenv gem for environment variables
+gem 'dotenv-rails', group: :development
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,10 @@ GEM
     docile (1.1.5)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.5.0)
+    dotenv-rails (2.5.0)
+      dotenv (= 2.5.0)
+      railties (>= 3.2, < 6.0)
     erubi (1.7.1)
     exception_handler (0.8.0.0)
       bundler
@@ -253,6 +257,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   coveralls
   devise
+  dotenv-rails
   exception_handler (~> 0.8.0.0)
   haml
   jbuilder (~> 2.8)


### PR DESCRIPTION
Development environments now support `.env` files for environment variables

Signed-off-by: microlith57 <microlith57@gmail.com>
